### PR TITLE
Fix coordinator address in emails

### DIFF
--- a/api/notifications/notifications.py
+++ b/api/notifications/notifications.py
@@ -22,13 +22,13 @@ def send_invite(user):
         form = PasswordResetForm({'email': user.email})
         form.is_valid()  # Needed for the `save()` to work.
         form.save(domain_override=site_url.split('://')[-1],
-                email_template_name='registration/invitation_email.txt',
-                subject_template_name='registration/invitation_subject.txt',
-                extra_email_context={
-                    'recipient': user.first_name,
-                    'site_name': site_name,
-                    'site_url': site_url
-                })
+                  email_template_name='registration/invitation_email.txt',
+                  subject_template_name='registration/invitation_subject.txt',
+                  extra_email_context={
+            'recipient': user.first_name,
+            'site_name': site_name,
+            'site_url': site_url
+        })
 
 
 def create_action_notifications(action):
@@ -38,18 +38,17 @@ def create_action_notifications(action):
     """
     # New, high-priority, pending actions trigger an email to appropriate volunteers.
     if action.action_priority == ActionPriority.HIGH \
-    and action.action_status == ActionStatus.PENDING \
-    and not notification_exists(action, NotificationTypes.PENDING_HIGH_PRIORITY):
+            and action.action_status == ActionStatus.PENDING \
+            and not notification_exists(action, NotificationTypes.PENDING_HIGH_PRIORITY):
         create([v.email for v in action.potential_volunteers], action=action,
-            notification_type=NotificationTypes.PENDING_HIGH_PRIORITY)
+               notification_type=NotificationTypes.PENDING_HIGH_PRIORITY)
 
     # Action coordinator is notified when a volunteer shows interest in an action.
     elif action.action_status == ActionStatus.INTEREST \
-    and not notification_exists(action, NotificationTypes.VOLUNTEER_INTEREST):
+            and not notification_exists(action, NotificationTypes.VOLUNTEER_INTEREST):
         create([coordinator_email], action=action,
-            notification_type=NotificationTypes.VOLUNTEER_INTEREST,
-            context={"volunteer_name": action.interested_volunteers.first().first_name})
-
+               notification_type=NotificationTypes.VOLUNTEER_INTEREST,
+               context={"volunteer_name": action.interested_volunteers.first().first_name})
 
     # Volunteers are notified about whether or not they're assigned to an action.
     elif action.action_status == ActionStatus.ASSIGNED:
@@ -58,78 +57,77 @@ def create_action_notifications(action):
         # If this notification hasn't been sent before, or if it was previously
         # sent to someone else, we should send it to the assigned volunteer.
         if not notification_exists(action, NotificationTypes.VOLUNTEER_ASSIGNED) \
-        or action.assigned_volunteer.email != get_latest_notification(action,
-        NotificationTypes.VOLUNTEER_ASSIGNED).recipients[0]:
+            or action.assigned_volunteer.email != get_latest_notification(action,
+                                                                          NotificationTypes.VOLUNTEER_ASSIGNED).recipients[0]:
             create([action.assigned_volunteer.email], action=action,
-                notification_type=NotificationTypes.VOLUNTEER_ASSIGNED)
-        
+                   notification_type=NotificationTypes.VOLUNTEER_ASSIGNED)
+
         # 2. Let those not assigned know.
         # Only send a notification to volunteers that have not received this email for this action.
-        notifications = get_all_notifications(action, NotificationTypes.VOLUNTEER_NOT_ASSIGNED)
-        already_received = set([r for n in notifications for r in n.recipients])
-        recipients = [v.email for v in action.interested_volunteers.all() 
-            if v.email not in already_received and 
-            v.id != action.assigned_volunteer.id]
-        
-        if len(recipients) > 0:
-            create(recipients, action=action, 
-                notification_type=NotificationTypes.VOLUNTEER_NOT_ASSIGNED)
+        notifications = get_all_notifications(
+            action, NotificationTypes.VOLUNTEER_NOT_ASSIGNED)
+        already_received = set(
+            [r for n in notifications for r in n.recipients])
+        recipients = [v.email for v in action.interested_volunteers.all()
+                      if v.email not in already_received and
+                      v.id != action.assigned_volunteer.id]
 
+        if len(recipients) > 0:
+            create(recipients, action=action,
+                   notification_type=NotificationTypes.VOLUNTEER_NOT_ASSIGNED)
 
     # Action coordinator is notified when a volunteer completes an action.
     elif action.action_status == ActionStatus.COMPLETED \
-    and not notification_exists(action, NotificationTypes.ACTION_COMPLETED):
+            and not notification_exists(action, NotificationTypes.ACTION_COMPLETED):
         create([coordinator_email], action=action,
-            notification_type=NotificationTypes.ACTION_COMPLETED)
-
+               notification_type=NotificationTypes.ACTION_COMPLETED)
 
     # Coordinators are notified when a volunteer can't complete an action.
     elif action.action_status == ActionStatus.COULDNT_COMPLETE \
-    and not notification_exists(action, NotificationTypes.ACTION_NOT_COMPLETED):
+            and not notification_exists(action, NotificationTypes.ACTION_NOT_COMPLETED):
         create([coordinator_email], action=action,
-            notification_type=NotificationTypes.ACTION_NOT_COMPLETED)
-
+               notification_type=NotificationTypes.ACTION_NOT_COMPLETED)
 
     # Coordinators are notified when an action is set to ongoing.
     elif action.action_status == ActionStatus.ONGOING and \
-    not notification_exists(action, NotificationTypes.ACTION_ONGOING):
-        create([coordinator_email], action=action, 
-            notification_type=NotificationTypes.ACTION_ONGOING)
-    
-    if action.volunteer_made_contact_on \
-    and not notification_exists(action, NotificationTypes.VOLUNTEER_CONTACT):
+            not notification_exists(action, NotificationTypes.ACTION_ONGOING):
         create([coordinator_email], action=action,
-            notification_type=NotificationTypes.VOLUNTEER_CONTACT)
+               notification_type=NotificationTypes.ACTION_ONGOING)
+
+    if action.volunteer_made_contact_on \
+            and not notification_exists(action, NotificationTypes.VOLUNTEER_CONTACT):
+        create([coordinator_email], action=action,
+               notification_type=NotificationTypes.VOLUNTEER_CONTACT)
 
 
 def notification_exists(action, notification_type):
     """True if a notification has been sent for
     this Action and NotificationType."""
     return Notification.objects \
-            .filter(action=action) \
-            .filter(type=notification_type) \
-            .first() is not None
+        .filter(action=action) \
+        .filter(type=notification_type) \
+        .first() is not None
 
 
 def get_latest_notification(action, notification_type):
     """Returns the latest notification for this Action and NotificationType."""
     return Notification.objects \
-            .filter(action=action) \
-            .filter(type=notification_type) \
-            .order_by('-created_date_time') \
-            .first()
+        .filter(action=action) \
+        .filter(type=notification_type) \
+        .order_by('-created_date_time') \
+        .first()
 
 
 def get_all_notifications(action, notification_type):
     """Returns all notifications for this Action and NotificationType."""
     return Notification.objects \
-            .filter(action=action) \
-            .filter(type=notification_type) \
-            .order_by('-created_date_time') \
-            .all()
+        .filter(action=action) \
+        .filter(type=notification_type) \
+        .order_by('-created_date_time') \
+        .all()
 
 
-def create(recipients, subject=None, message=None, action=None, 
+def create(recipients, subject=None, message=None, action=None,
            notification_type=None, context={}):
     """Instantiates notifications.
     Generates a notification subject and message,
@@ -137,6 +135,7 @@ def create(recipients, subject=None, message=None, action=None,
     """
     # Pass the action as context to the email templates.
     context["action"] = action
+    context["coordinator_email"] = coordinator_email
 
     # Generate a subject and message based on the notification_type.
     gen_subject, gen_message = gen_subject_and_message(

--- a/api/notifications/templates/notifications/volunteer_assigned_message.txt
+++ b/api/notifications/templates/notifications/volunteer_assigned_message.txt
@@ -7,6 +7,6 @@ You have been approved to help with an action, here are the details:
 
 As ever, please contact the resident ASAP so they know they have a volunteer/buddy and to make the arrangements.  We would recommend you shield your telephone number when doing this.  Please update the details for this action on To/Fro when you have made contact and when you have completed the action (whether one off or ongoing), and put in the time taken to complete.  Once you have done that, please delete all personal details for the resident so you're not holding their data unnecessarily.
 
-If you are having difficulty completing the help offer on time, or if there is something you’d like to flag with a coordinator, please email feedback@knowlewestalliance.co.uk.
+If you are having difficulty completing the help offer on time, or if there is something you’d like to flag with a coordinator, please email {{ coordinator_email }}.
 
 Many thanks and best wishes from the KW Support Hub Team


### PR DESCRIPTION
Reused the `COORDINATOR_EMAIL` environment variable to make sure that it's the same address that shows in the emails and the site (instead of the previously hard-coded `feedback@...` in the email vs `info@...` on the site).