### PR TITLE
Update redirection URL after password reset to match the user profile

### DIFF
--- a/api/core/templates/admin/base_site.html
+++ b/api/core/templates/admin/base_site.html
@@ -23,7 +23,7 @@
   {% if user.has_usable_password %}
   <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a> /
   {% endif %}
-  <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
+  <a href="{% url 'logout' %}">{% trans 'Log out' %}</a>
 {% endblock %}
 
 {% block extrahead %}

--- a/api/tofro/urls.py
+++ b/api/tofro/urls.py
@@ -10,7 +10,7 @@ from django.urls import include, path
 from django.conf import settings
 from django.conf.urls import url
 from django.contrib import admin
-from tofro.views import LoginView, PasswordResetConfirmView, homepage
+from tofro.views import LoginView, LogoutView, PasswordResetConfirmView, homepage
 from tofro.lib import login_required
 from django.contrib.flatpages import views
 
@@ -24,6 +24,7 @@ urlpatterns = [
     path('accounts/', include('django.contrib.auth.urls')),
     path('actions/', decorator_include(login_required, ('actions.urls', 'actions'))),
     path('accounts/login', LoginView.as_view(), name="login"),
+    path('accounts/logout', LogoutView.as_view(), name="logout")
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) + [
     re_path(r'^(?P<url>.*/)$', views.flatpage, name="page"),
 ]

--- a/api/tofro/views.py
+++ b/api/tofro/views.py
@@ -29,6 +29,14 @@ class LoginRedirection:
         return reverse('admin:index')
 
 
+class LogoutView(views.LogoutView):
+    next_page = reverse_lazy('home')
+
+    def get_next_page(self):
+        messages.success(self.request, "You're now logged out!")
+        return super().get_next_page()
+
+
 class LoginView(LoginRedirection, views.LoginView):
     """
     Custom LoginView that redirects users after login


### PR DESCRIPTION
Volunteers will be redirected to the volunteer dashboard and Coordinators to the admin. If a user has both profiles, the Volunteer redirection will take precedence.

I also tweaked the redirection after logout, to send users back straight to the login page rather than the current hold page that just says "Logged out" and requires a click to log in again.