### PR TITLE
Bugfix/duplicate account creation

### DIFF
--- a/api/core/backends.py
+++ b/api/core/backends.py
@@ -7,11 +7,15 @@ class EmailBackend(ModelBackend):
     """Custom email auth backend.
     Based on https://stackoverflow.com/a/37332393
     """
+
     def authenticate(self, request, username=None, password=None, **kwargs):
         UserModel = get_user_model()
         try:
+            # Use `__iexact` for the email lookup as emails are case insensitive by nature
+            # and there might be emails in varying capitalisation in the DB
+            # from prior to the fix lowecasing all emails
             user = UserModel.objects.get(
-                Q(email=username) | Q(username=username))
+                Q(email__iexact=username) | Q(username=username))
         except UserModel.DoesNotExist:
             return None
         else:

--- a/api/users/admin.py
+++ b/api/users/admin.py
@@ -50,6 +50,19 @@ class CoordinatorForm(UserProfileForm):
         model = Coordinator
         fields = '__all__'
 
+    # Ideally this should be handled at model level
+    # or through signals, but can't track if user has
+    # been modified there as the tracker for modified
+    # attributes doesn't seem to track the changed
+    # for the OneToOne relation OK here
+    def is_valid(self, *args, **kwargs):
+        """
+        `is_valid` implementation to store previous user
+        `save` is too late, the instance has already been replaced
+        """
+        self.instance.previous_user = self.instance.user
+        return super().is_valid(*args, **kwargs)
+
 
 class CoordinatorAdmin(ModelAdminWithExtraContext):
     form = CoordinatorForm

--- a/api/users/admin.py
+++ b/api/users/admin.py
@@ -14,6 +14,14 @@ logger = logging.getLogger(__name__)
 
 
 class UserProfileForm(forms.ModelForm):
+
+    def clean_email(self):
+        """
+        Makes sure the email is lowercased so that emails with different
+        cases don't end up creating duplicate accounts
+        """
+        return self.cleaned_data['email'].lower()
+
     def clean(self):
         super().clean()
         if (not self.cleaned_data.get('user_without_account')):

--- a/api/users/signals.py
+++ b/api/users/signals.py
@@ -155,11 +155,11 @@ def sync_user(source, target, attrs=USER_FIELDS_TO_SYNC):
 def transfer_coordinator_status(sender, instance, **kwargs):
     previous_user = instance.previous_user
     new_user = instance.user
-
-    previous_user.is_staff = False
-    previous_user.is_superuser = False
-    previous_user.coordinator = None
-    previous_user.save()
+    if previous_user:
+        previous_user.is_staff = False
+        previous_user.is_superuser = False
+        previous_user.coordinator = None
+        previous_user.save()
 
     new_user.is_staff = True
     new_user.is_superuser = True

--- a/api/users/signals.py
+++ b/api/users/signals.py
@@ -10,6 +10,10 @@ User = get_user_model()
 
 logger = logging.getLogger(__name__)
 
+###
+# Wards and help types
+###
+
 
 @receiver(post_save, sender=HelpType, dispatch_uid="HelpTypeOptIn")
 @receiver(post_save, sender=Ward, dispatch_uid="WardOptIn")
@@ -22,6 +26,10 @@ def post_save_category(sender, instance, created, **kwargs):
         instance.volunteers.set(Volunteer.objects.all())
         instance.save()
 
+###
+# Settings profile
+###
+
 
 @receiver(post_save, sender=User, dispatch_uid="CreateUserSettings")
 def create_user_settings(sender, instance, created, **kwargs):
@@ -30,6 +38,10 @@ def create_user_settings(sender, instance, created, **kwargs):
     """
     if created:
         Settings(user=instance).save()
+
+###
+# Personal information synchronisation
+###
 
 
 USER_FIELDS_TO_SYNC = (
@@ -81,17 +93,6 @@ def post_save_volunteer(sender, instance, created, **kwargs):
                         instance.user.volunteer.save()
 
 
-@receiver(post_save, sender=User, dispatch_uid="UserSaved")
-def post_save_user(sender, instance, created, **kwargs):
-    if not created:
-        # Need to check before accessing relations
-        # as it would throw a NotFoundException
-        if (instance.is_volunteer):
-            update_profile_info(instance.volunteer, instance)
-        if (instance.is_coordinator):
-            update_profile_info(instance.coordinator, instance)
-
-
 def update_profile_info(profile, user):
     # Only save if there's been a change,
     # to avoid looping infinitely
@@ -139,6 +140,32 @@ def sync_user(source, target, attrs=USER_FIELDS_TO_SYNC):
     changed = sync(source, target, attrs)
     return changed or sync_attr(source, target, 'email', 'username')
 
+###
+# User status synchronisation for coordiantors
+###
+
+
+# Ideally, if this could be moved in the Coordinator class
+# so that the code creating the user with the right permissions
+# and the one adjusting their permission was in the same place,
+# that would be ideal
+
+
+@receiver(post_save, sender=Coordinator, dispatch_uid="CoordinatorUpdated")
+def transfer_coordinator_status(sender, instance, **kwargs):
+    previous_user = instance.previous_user
+    new_user = instance.user
+
+    previous_user.is_staff = False
+    previous_user.is_superuser = False
+    previous_user.coordinator = None
+    previous_user.save()
+
+    new_user.is_staff = True
+    new_user.is_superuser = True
+    # No need to set coordinator as it is already set by Django
+    new_user.save()
+
 
 @receiver(post_delete, sender=Coordinator, dispatch_uid="CoordinatorDeleted")
 def post_delete_coordinator(sender, instance, **kwargs):
@@ -146,22 +173,27 @@ def post_delete_coordinator(sender, instance, **kwargs):
     Automatically delete users if there's no profile attached to them
     or adjust privileges
     """
-    if not instance.user.is_volunteer:
-        instance.user.delete()
-    else:
-        # Remove superuser and staff privileges
-        # for non-coordinator users
-        user = instance.user
-        user.is_staff = False
-        user.is_superuser = False
-        user.coordinator = None
-        user.save()
+    # Remove superuser and staff privileges
+    # for non-coordinator users
+    user = instance.user
+    user.is_staff = False
+    user.is_superuser = False
+    user.coordinator = None
+    user.save()
+
+###
+# User information coordination
+###
 
 
-@receiver(post_delete, sender=Volunteer, dispatch_uid="VolunteerDeleted")
-def post_delete_user_profile(sender, instance, **kwargs):
-    """
-    Automatically delete users if there's no profile attached to them
-    """
-    if not instance.user.is_coordinator:
-        instance.user.delete()
+@receiver(post_save, sender=User, dispatch_uid="UserSaved")
+def post_save_user(sender, instance, created, **kwargs):
+    if not created:
+        # Need to check before accessing relations
+        # as it would throw a NotFoundException
+        if (instance.is_volunteer):
+            update_profile_info(instance.volunteer, instance)
+        if (instance.is_coordinator):
+            update_profile_info(instance.coordinator, instance)
+        if not instance.is_coordinator and not instance.is_volunteer:
+            instance.delete()


### PR DESCRIPTION
This fixes duplicate accounts created when a Volunteer and Coordinator profile are created with different capitalizations for the email address (for ex. romaric@example.com and Romaric@example.com, which would have created two different accounts).

This also fixes consequences for updating the account linked to a Coordinator profile:
- staff and superuser status of the previous account get removed
- staff and superuser status are added to the new account
- if the previous account doesn't have any other profile attached, it gets deleted, just like when deleting profiles