### PR TITLE
Fix display of list of volunteer when creating an action

### DIFF
--- a/api/actions/admin.py
+++ b/api/actions/admin.py
@@ -128,9 +128,10 @@ class AssignedVolunteerAutocompleteSelect(AutocompleteSelect):
     def build_attrs(self, base_attrs, extra_attrs=None):
         attrs = super().build_attrs(base_attrs, extra_attrs=extra_attrs)
         url = attrs['data-ajax--url']
-        query_param = f"with_interest_for={self.model_instance.pk}"
-        join_char = "&" if "?" in url else "?"
-        attrs['data-ajax--url'] = f"{url}{join_char}{query_param}"
+        if (self.model_instance.pk):
+            query_param = f"with_interest_for={self.model_instance.pk}"
+            join_char = "&" if "?" in url else "?"
+            attrs['data-ajax--url'] = f"{url}{join_char}{query_param}"
         return attrs
 
 


### PR DESCRIPTION
When creating an action, the list of volunteer will now load properly. If a volunteer gets assigned on creation, the action will automatically shift status to "volunteer assigned". The co-ordinator creating an action can still chose another status (aside from Pending and Volunteer interest), for example "completed" and this will be respected. 


It will *not* display a star for volunteers that have already helped the selected resident. The value is currently driven by the resident stored in the database rather than the one selected in the frontend. Changing this will require looking into updating the URL used by the autocomplete widget based on the selected resident.