### PR TITLE
limit the number of items shown on action list in the admin

### DIFF
--- a/api/actions/admin.py
+++ b/api/actions/admin.py
@@ -9,7 +9,7 @@ from django.db import models
 from django import forms
 import datetime
 from django.utils.translation import gettext_lazy as _
-from core.admin import ModelAdminWithExtraContext
+from core.admin import ModelAdminWithDefaultPagination, ModelAdminWithExtraContext
 from admin_auto_filters.filters import AutocompleteFilter
 from django_admin_listfilter_dropdown.filters import ChoiceDropdownFilter
 
@@ -170,7 +170,7 @@ class FeedbackInline(admin.TabularInline):
     extra = 0
 
 
-class ActionAdmin(ModelAdminWithExtraContext):
+class ActionAdmin(ModelAdminWithDefaultPagination, ModelAdminWithExtraContext):
     form = ActionAdminForm
     list_display = ('id', 'resident', 'help_type',
                     'requested_datetime', 'has_volunteer_made_contact',  'action_status', 'assigned_volunteer', 'time_taken')
@@ -283,7 +283,7 @@ class ActionAdmin(ModelAdminWithExtraContext):
     has_volunteer_made_contact.short_description = "Contact"
 
 
-class ActionFeedbackAdmin(ModelAdminWithExtraContext):
+class ActionFeedbackAdmin(ModelAdminWithDefaultPagination, ModelAdminWithExtraContext):
     list_display = ('id', 'action', 'volunteer', 'resident',
                     'time_taken', 'created_date_time')
     list_filter = ('volunteer', 'action', 'created_date_time')

--- a/api/categories/admin.py
+++ b/api/categories/admin.py
@@ -2,14 +2,15 @@ from django import forms
 from django.contrib import admin
 from .models import Ward, HelpType, Requirement
 
+from core.admin import ModelAdminWithDefaultPagination
 from django.utils.translation import gettext as _
 from markup_help.templatetags.svg import fontawesome_icon_exists
 
 import logging
 logger = logging.getLogger(__name__)
 
-admin.site.register(Ward)
-admin.site.register(Requirement)
+admin.site.register(Ward, ModelAdminWithDefaultPagination)
+admin.site.register(Requirement, ModelAdminWithDefaultPagination)
 
 
 class HelpTypeForm(forms.ModelForm):
@@ -29,7 +30,7 @@ class HelpTypeForm(forms.ModelForm):
         fields = '__all__'
 
 
-class HelpTypeAdmin(admin.ModelAdmin):
+class HelpTypeAdmin(ModelAdminWithDefaultPagination):
     form = HelpTypeForm
     fieldsets = (
         (None, {'fields': ('name', 'icon_name')}),

--- a/api/core/admin.py
+++ b/api/core/admin.py
@@ -1,6 +1,10 @@
 from django.contrib import admin
 
 
+class ModelAdminWithDefaultPagination(admin.ModelAdmin):
+    list_per_page = 20
+
+
 class ModelAdminWithExtraContext(admin.ModelAdmin):
     """
     Base class for creating an admin that automatically adds some

--- a/api/pages_and_menus/admin.py
+++ b/api/pages_and_menus/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
 from sitetree import admin as sitetree_admin, models
+from core.admin import ModelAdminWithDefaultPagination
 from django.urls import reverse
 from django.contrib.sites.models import Site
 from django.contrib.flatpages import admin as flatpages_admin, models
@@ -10,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class TreeAdmin(sitetree_admin.TreeAdmin):
+class TreeAdmin(ModelAdminWithDefaultPagination, sitetree_admin.TreeAdmin):
     """
     Reduce options to add/remove menus in the admin
     So that only the main navigation appears and cannot be removed
@@ -24,7 +25,7 @@ class TreeAdmin(sitetree_admin.TreeAdmin):
         return False
 
 
-class TreeItemAdmin(sitetree_admin.TreeItemAdmin):
+class TreeItemAdmin(ModelAdminWithDefaultPagination, sitetree_admin.TreeItemAdmin):
     """
     Reduce fields available when editing TreeItems
     """
@@ -42,7 +43,7 @@ sitetree_admin.override_tree_admin(TreeAdmin)
 sitetree_admin.override_item_admin(TreeItemAdmin)
 
 
-class FlatPageAdmin(flatpages_admin.FlatPageAdmin):
+class FlatPageAdmin(ModelAdminWithDefaultPagination, flatpages_admin.FlatPageAdmin):
     """
     Customization of the FlatPageAdmin
     """

--- a/api/users/admin.py
+++ b/api/users/admin.py
@@ -6,7 +6,7 @@ from django.contrib.auth.admin import UserAdmin
 from django import forms
 from django.utils.translation import gettext as _
 from django.db.models import Q, IntegerField, Case, When, Value
-from core.admin import ModelAdminWithExtraContext
+from core.admin import ModelAdminWithDefaultPagination, ModelAdminWithExtraContext
 from django.contrib.admin.views.autocomplete import AutocompleteJsonView
 
 import logging
@@ -64,7 +64,7 @@ class CoordinatorForm(UserProfileForm):
         return super().is_valid(*args, **kwargs)
 
 
-class CoordinatorAdmin(ModelAdminWithExtraContext):
+class CoordinatorAdmin(ModelAdminWithDefaultPagination, ModelAdminWithExtraContext):
     form = CoordinatorForm
 
     def extra_context(self, object_id=None):
@@ -99,7 +99,7 @@ class CoordinatorAdmin(ModelAdminWithExtraContext):
     ordering = ('last_name', 'email')
 
 
-class ResidentAdmin(admin.ModelAdmin):
+class ResidentAdmin(ModelAdminWithDefaultPagination):
     model = Resident
     list_display = ('first_name', 'last_name',
                     'phone', 'email', 'time_received')
@@ -144,7 +144,7 @@ class VolunteerAutocompleteJsonView(AutocompleteJsonView):
         return data
 
 
-class VolunteerAdminAutocomplete(admin.ModelAdmin):
+class VolunteerAdminAutocomplete(ModelAdminWithDefaultPagination):
     """
     Mixin wrapping the customisations of the autocomplete
     for the Volunteer admin
@@ -240,7 +240,7 @@ class VolunteerAdmin(VolunteerAdminAutocomplete, ModelAdminWithExtraContext):
     )
 
 
-class ToFroUserAdmin(UserAdmin):
+class ToFroUserAdmin(ModelAdminWithDefaultPagination, UserAdmin):
     """
     Customization of the user admin to allow filtering of the autocomplete
     so it returns only Users that don't already have a profile


### PR DESCRIPTION
All the admin lists should now be limited to 20 elements (there's a "Show all" link if people want to see all items anyway). 

The number of items per page can be change site wide in the `ModelAdminWithDefaultPagination` class, or on specific admins, by changing/setting the `list_per_page` value.