### PR TITLE
Add validation for assigned volunteer requirements

### DIFF
--- a/api/actions/admin.py
+++ b/api/actions/admin.py
@@ -152,12 +152,71 @@ class ActionAdminForm(forms.ModelForm):
 
     def clean(self):
         super().clean()
-        if (not self.cleaned_data['assigned_volunteer']
-                and self.cleaned_data['action_status'] not in Action.STATUSES_WITHOUT_ASSIGNED_VOLUNTEER + (ActionStatus.NO_LONGER_NEEDED,)):
+
+        assigned_volunteer = self.get_field_value('assigned_volunteer')
+        action_status = self.get_field_value('action_status')
+
+        # Not plainly accessing cleaned_data.get('requirements')
+        # is important here, as the list form does not send requirements
+        requirements = self.get_field_value('requirements').all()
+
+        self.validate_assigned_volunteer_for_status(
+            assigned_volunteer, action_status)
+        self.validate_missing_requirements(assigned_volunteer, requirements)
+
+    def validate_assigned_volunteer_for_status(self, assigned_volunteer, action_status):
+        """
+        Ensure a volunteer is set when the status requires it
+        """
+        if (not assigned_volunteer
+                and action_status not in Action.STATUSES_WITHOUT_ASSIGNED_VOLUNTEER + (ActionStatus.NO_LONGER_NEEDED,)):
             raise forms.ValidationError(
                 _("Please make sure to update the action status when no volunteer is assigned"),
                 code='invalid-status-for-unassigning-volunteer'
             )
+
+    def validate_missing_requirements(self, assigned_volunteer, requirements):
+        """
+        Ensure the assigned volunteer has all necessary requirements
+
+        Only runs if the volunteer or requirements has changed to avoid
+        querying the database on all saves
+        """
+
+        # Need to compare the list of requirements
+        # https://stackoverflow.com/a/54117086
+        has_requirements_changed = set(
+            self.instance.requirements.all()) != set(requirements)
+
+        # Volunteer gives us the volunteer instance straight away though
+        has_volunteer_changed = assigned_volunteer != self.instance.assigned_volunteer
+
+        # Cast the QuerySet to boolean to ensure proper value
+        should_validate = bool(requirements) and bool(assigned_volunteer) and (
+            has_requirements_changed or has_volunteer_changed)
+
+        if (should_validate):
+            missing_requirements = assigned_volunteer.missing_requirements(
+                requirements)
+            if (missing_requirements):
+                raise forms.ValidationError(
+                    _("The assigned volunteer is missing the following requirements: %(requirements)s"),
+                    code="assigned-volunteer-missing-requirements",
+                    params={
+                        'requirements': ', '.join([r.name for r in missing_requirements])
+                    }
+                )
+
+    def get_field_value(self, field_name):
+        """
+        Reads the value of given `field_name`,
+        using the submitted data if it exists,
+        and using the instance value otherwise
+        """
+        if (field_name in self.cleaned_data):
+            return self.cleaned_data.get(field_name)
+        else:
+            return getattr(self.instance, field_name)
 
     class Meta:
         model = Action

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -232,6 +232,12 @@ class Volunteer(UserProfileMixin, Person):
     def ongoing_actions(self):
         return self.action_set.filter(action_status=action_models.ActionStatus.ONGOING)
 
+    def missing_requirements(self, requirements):
+        """
+        Lists Requirements from given list that this volunteer is missin
+        """
+        return requirements.filter(~Q(pk__in=self.requirements.all()))
+
 
 class Coordinator(UserProfileMixin, Person):
     profile_related_name = 'coordinator'


### PR DESCRIPTION
Picking a volunteer that doesn't match requirements will now raise an error and prevent saving the action. This is mostly for when co-ordinators want to assign someone that hasn't volunteered.

The checks happen both when picking in the list of actions or when editing a single action:

![tofro-requirements-check-on-list](https://user-images.githubusercontent.com/396367/90011749-109cb080-dc9a-11ea-8e98-cd40d43b4187.png)
![tofro-requirements-check](https://user-images.githubusercontent.com/396367/90011752-11354700-dc9a-11ea-880d-8394e10b11a8.png)
